### PR TITLE
Fix package dependencies of elfin_robot_bringup launch files

### DIFF
--- a/elfin_robot_bringup/package.xml
+++ b/elfin_robot_bringup/package.xml
@@ -4,48 +4,16 @@
   <version>0.0.0</version>
   <description>The elfin_robot_bringup package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="liucong.cdhaw@gmail.com">Cong Liu</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>BSD</license>
 
-
-  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/elfin_bringup</url> -->
-
-
-  <!-- Author tags are optional, mutiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintianers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
   <author email="liucong.cdhaw@gmail.com">Cong Liu</author>
 
-
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
+  <run_depend>controller_manager</run_depend>
+  <run_depend>elfin_ros_control</run_depend>
+  <run_depend>elfin_ros_control_v2</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
 </package>


### PR DESCRIPTION
This adds all the packages that are used in the launch files to the run_depends of the package.

You can verify if the dependencies are correct by running the following command:
```sh
rosrun roslaunch roslaunch-check "$(rospack find elfin_robot_bringup)/launch"
```