### PR TITLE
Fix missing dependency on joint_trajectory_controller

### DIFF
--- a/elfin_gazebo/package.xml
+++ b/elfin_gazebo/package.xml
@@ -47,6 +47,7 @@
   <run_depend>elfin_description</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
+  <run_depend>joint_trajectory_controller</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/elfin_robot_bringup/package.xml
+++ b/elfin_robot_bringup/package.xml
@@ -15,5 +15,6 @@
   <run_depend>controller_manager</run_depend>
   <run_depend>elfin_ros_control</run_depend>
   <run_depend>elfin_ros_control_v2</run_depend>
+  <run_depend>joint_trajectory_controller</run_depend>
   <run_depend>robot_state_publisher</run_depend>
 </package>


### PR DESCRIPTION
In the launch files, several controllers from the
`joint_trajectory_controller` package are launches. This adds this
dependency to the package xml.

In these files they are used:
```
elfin_robot_bringup/config/elfin_module_control.yaml
2:  type: position_controllers/JointTrajectoryController

elfin_robot_bringup/config/elfin_arm_control.yaml
2:  type: position_controllers/JointTrajectoryController

elfin_gazebo/config/elfin_arm_control.yaml
2:  type: position_controllers/JointTrajectoryController

elfin_gazebo/config/elfin_module_control.yaml
2:  type: position_controllers/JointTrajectoryController
```